### PR TITLE
[WIP] RSS Feed for personal Patreon Feed

### DIFF
--- a/src/Patreon/Feed.php
+++ b/src/Patreon/Feed.php
@@ -103,11 +103,6 @@ class Feed extends PatreonRSS
         }
     }
 
-    public function setSessionId($session_id)
-    {
-        $this->session_id=$session_id;
-    }
-
     /**
      * @param $field
      * @return $this

--- a/src/Patreon/Feed.php
+++ b/src/Patreon/Feed.php
@@ -103,6 +103,11 @@ class Feed extends PatreonRSS
         }
     }
 
+    public function setSessionId($session_id)
+    {
+        $this->session_id=$session_id;
+    }
+
     /**
      * @param $field
      * @return $this

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -61,8 +61,8 @@ class PatreonRSS
 
     /** @var array haven't really played with those, except the creator id */
     protected $filter = array(
-        // Keys, see #setCreatorId
-        // 'is_following'
+        'is_following' => true,
+        // other keys, see #setCreatorId
         // 'is_by_creator'
         // 'creator_id'
         // 'contains_exclusive_posts'

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -99,6 +99,11 @@ class PatreonRSS
         return $this;
     }
 
+    public function setSessionId($session_id)
+    {
+        $this->session_id=$session_id;
+    }
+
     /**
      * Output the RSS directly to the browser
      */

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -282,7 +282,7 @@ class PatreonRSS
             if(substr($header, 0, $prefix_len) === $prefix)
             {
                 $this->setSessionId(substr($header, $prefix_len, strpos($header, ";") - $prefix_len));
-                break;
+                return $this->session_id;
             }
         }
 

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -61,10 +61,11 @@ class PatreonRSS
 
     /** @var array haven't really played with those, except the creator id */
     protected $filter = array(
-        'is_by_creator' => true,
-        'is_following' => false,
-        'creator_id' => 'set by constructor',
-        'contains_exclusive_posts' => true
+        // Keys, see #setCreatorId
+        // 'is_following'
+        // 'is_by_creator'
+        // 'creator_id'
+        // 'contains_exclusive_posts'
     );
 
     /**
@@ -76,7 +77,7 @@ class PatreonRSS
     public function __construct($id = null)
     {
         if (!empty($id)) {
-            $this->filter['creator_id'] = $id;
+            $this->setCreatorID($id);
         }
     }
 
@@ -86,7 +87,12 @@ class PatreonRSS
      */
     public function setCreatorID($id)
     {
-        $this->filter['creator_id'] = $id;
+        $this->filter = array_merge($this->filter, array(
+            'is_by_creator' => true,
+            'is_following' => false,
+            'creator_id' => $id,
+            'contains_exclusive_posts' => true
+        ));
         return $this;
     }
 


### PR DESCRIPTION
As of #1, here the PR for that.

One-liner to test:

```shell
$ php -r 'require("vendor/autoload.php"); $patreon = new \daemionfox\Patreon\PatreonRSS(); \
$patreon->login("'"$PATREON_MAIL"'", "'"$PATREON_PASS"'"); echo $patreon->rss();'` 
```

As you can see, currently only `PatreonRSS` is integrated, I am currently working on integrating it into the `Feed` class. :)

I use PHP Streams to obtain the required Session ID and the Patreon Stream, for this small use-case I thought no Guzzle or equivalent is needed.
If you want I can change that to Guzzle, I'm open for that.

Thank you.

Closes #1.