### PR TITLE
Integrate Personal feed into main Feed class

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,14 @@ $rss = $patreon->rss();
 echo $rss;
 ```
 
+
+```php
+// Login to access your private feed.
+$patreon = new \daemionfox\Patreon\Feed("user@example.com", "1n53cur3");
+$rss = $patreon->rss();
+echo $rss;
+```
+
 ### Caching
 
 Feed has the ability to set a cache path and turn on caching via static methods.

--- a/src/Patreon/Feed.php
+++ b/src/Patreon/Feed.php
@@ -94,12 +94,23 @@ class Feed extends PatreonRSS
     /** @noinspection PhpMissingParentConstructorInspection */
     /**
      * Feed constructor.
+     * If password is given, treat creator name as login email.
      * @param null $creator
+     * @param null $password
      */
-    public function __construct($creator = null)
+    public function __construct($creator = null, $password = null)
     {
-        if ($creator !== null) {
-            $this->setCreator($creator);
+        if ($creator !== null)
+        {
+            if($password === null)
+            {
+                $this->setCreator($creator);
+            }
+            else
+            {
+                $this->login($creator, $password);
+                $this->getPatreon();
+            }
         }
     }
 

--- a/src/Patreon/Feed.php
+++ b/src/Patreon/Feed.php
@@ -45,11 +45,6 @@ class Feed extends PatreonRSS
     protected $posts;
 
     /**
-     * @var User
-     */
-    protected $user;
-
-    /**
      * @var Campaign
      */
     protected $campaign;

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -186,19 +186,35 @@ class PatreonRSS
             'user' => array(),
             'campaign' => array()
         );
+
         foreach ($data['data'] as $item) {
             $clean['posts'][] = $item['attributes'];
         }
-        foreach ($data['included'] as $item) {
-            if ($item['type'] == 'user') {
-                $clean['user'] = $item['attributes'];
-                $clean['user']['id'] = $item['id'];
-                continue;
+
+        if($this->session_id == null) // User and campaign do not make sense for personal feed
+        {
+            foreach ($data['included'] as $item) {
+                if ($item['type'] == 'user') {
+                    $clean['user'] = $item['attributes'];
+                    $clean['user']['id'] = $item['id'];
+                    continue;
+                }
+                if ($item['type'] == 'campaign') {
+                    $clean['campaign'] = $item['attributes'];
+                    $clean['campaign']['id'] = $item['id'];
+                }
             }
-            if ($item['type'] == 'campaign') {
-                $clean['campaign'] = $item['attributes'];
-                $clean['campaign']['id'] = $item['id'];
-            }
+        }
+        else
+        {
+            // Set minimal values for #printRssChannelInfo
+            $clean['user'] = array(
+                'url' => 'https://www.patreon.com/home'
+            );
+            $clean['campaign'] = array(
+                'creation_name' => 'Your', // "Your" instead of "[Creator]" in "[Creator] Patreon Posts"
+                'campaign_description' => ''
+            );
         }
 
         return $clean;

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -213,8 +213,9 @@ class PatreonRSS
         if($this->session_id == null) // No session key, no cookies required
         {
             return file_get_contents($url);
-        } else {
-
+        }
+        else
+        {
             $opts = array('http' =>
                 array(
                     'header'  => array(

--- a/src/Patreon/PatreonRSS.php
+++ b/src/Patreon/PatreonRSS.php
@@ -8,6 +8,7 @@
 
 namespace daemionfox\Patreon;
 
+use daemionfox\Patreon\Components\User;
 
 /**
  * Class PatreonRSS
@@ -70,6 +71,9 @@ class PatreonRSS
 
     /** @var string|null which contains the session key for this user, if available, otherwise null. */
     protected $session_id = null;
+
+    /** @var string|null the user of the private feed, if applicable, otherwise null. */
+    protected $user = null;
 
     /**
      * PatreonRSS constructor.
@@ -208,9 +212,6 @@ class PatreonRSS
         else
         {
             // Set minimal values for #printRssChannelInfo
-            $clean['user'] = array(
-                'url' => 'https://www.patreon.com/home'
-            );
             $clean['campaign'] = array(
                 'creation_name' => 'Your', // "Your" instead of "[Creator]" in "[Creator] Patreon Posts"
                 'campaign_description' => ''
@@ -285,11 +286,16 @@ class PatreonRSS
         // TODO move URL to constant
         $handle= fopen("https://www.patreon.com/api/login?json-api-version=1.0", "rb", false, $context);
 
-        stream_get_contents($handle); // consume body
-
+        $profile = json_decode(stream_get_contents($handle), true)['data'];
         $metadata = stream_get_meta_data($handle);
 
         fclose($handle);
+
+        $user_data = $profile['attributes'];
+        $user_data['id'] = $profile['id'];
+
+        $this->user = new User();
+        $this->user->load($user_data);
 
         $prefix = "Set-Cookie: session_id=";
         $prefix_len = strlen($prefix);


### PR DESCRIPTION
Allows accessing your private feed by specifying it in the constructor like so:

```php
$patreon = new \daemionfox\Patreon\Feed("user@example.com", "1n53cur3");
```

Also enables to get the logged in user via `Feed#getUser()`. :)

No WIP this time, so you can just merge it if you like.